### PR TITLE
Fix launch wireshark (#26)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -12063,13 +12063,21 @@ class MainWindow(QtWidgets.QMainWindow, form_class):
         
         # Find Wireshark
         out = subprocess.Popen(['which', 'wireshark'],stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
-        stdout,stderr = out.communicate()
-        wireshark_cmd = str(stdout.replace('\n',''))
-        
+        try:
+            stdout, _ = out.communicate(timeout=15)
+        except TimeoutError as err:
+            print("Error communicating with Wireshark: {}".format(err))
+
+        wireshark_cmd = stdout.decode('UTF-8').strip()
+        if not wireshark_cmd:
+            # TODO: display on GUI
+            print("Error wireshark not found")
+            return
+       
         if len(get_interface) == 0 and len(wireshark_cmd) > 0:
-            p = subprocess.Popen([wireshark_cmd])
+            subprocess.Popen([wireshark_cmd])
         else:
-            p = subprocess.Popen([wireshark_cmd, '-k', '-i', get_interface])
+            subprocess.Popen([wireshark_cmd, '-k', '-i', get_interface])
         
     def _slotPD_SnifferGuessClicked(self):
         """ Guesses the wireless interface to use for Wireshark.


### PR DESCRIPTION
Proposed changes to ```_slotPD_SnifferWireshark80211Clicked```

- ignore output to stderr
- remove unused variables
- return when wireshark is not found 
- handle communicate timeout exception
- decode bytes object to UTF-8 and strip new line 

Example when wireshark is not found: 

![Screenshot from 2022-09-30 12-57-34](https://user-images.githubusercontent.com/8560646/193323873-38a8d15e-aa65-43d6-ba47-a8d7f4a36727.png)

Additional possible feature request: 
- Display that wireshark is missing in GUI 