### PR TITLE
Fix for sensor_node_id in sensornode.py

### DIFF
--- a/fissure/Sensor_Node/SensorNode.py
+++ b/fissure/Sensor_Node/SensorNode.py
@@ -2339,7 +2339,7 @@ class SensorNode():
             with open(filename) as yaml_library_file:
                 playlist_dict = yaml.load(yaml_library_file, yaml.FullLoader)
                 trigger_dict = playlist_dict['trigger_values']
-            self.autorunPlaylistStart('', playlist_dict, trigger_dict)
+            self.autorunPlaylistStart(sensor_node_id, playlist_dict, trigger_dict)
 
 
     def autorunPlaylistThreadStart(self, sensor_node_id, playlist_dict):


### PR DESCRIPTION
This allows for the sensor node id to be passed to the autorunPlaylistExecute function