### PR TITLE
Add bladeRF 2.0 IQ recording support

### DIFF
--- a/Plugins/Base/actions.py
+++ b/Plugins/Base/actions.py
@@ -82,7 +82,7 @@ ACTION_HARDWARE = {
     "lfm_beacon_detection": ["RTL2832U"],
     "lfm_beacon_geolocate": ["RTL2832U"],
     "usrp_b2x0_geolocate": ["USRP B20xmini", "USRP B2x0"],
-    "iq_record": ["USRP B20xmini", "USRP B2x0"],
+    "iq_record": ["USRP B20xmini", "USRP B2x0", "bladeRF 2.0"],
     "iq_playback": ["USRP B20xmini", "USRP B2x0"],
 }
 
@@ -1149,6 +1149,7 @@ iq_record_schema = {
             "default": "iq_recorder_b2x0",
             "options": [
                 "iq_recorder_b2x0",
+                "iq_recorder_bladerf2",
             ],
         },
         {

--- a/Plugins/Base/flow_graphs/iq_record_flow_graphs/maint-3.10/bladerf2/iq_recorder_bladerf2.py
+++ b/Plugins/Base/flow_graphs/iq_record_flow_graphs/maint-3.10/bladerf2/iq_recorder_bladerf2.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Headless IQ recorder for a bladeRF 2.0 using GNU Radio's Soapy block."""
+
+from gnuradio import blocks
+from gnuradio import gr
+from gnuradio import soapy
+
+
+class iq_recorder_bladerf2(gr.top_block):
+    """Record a finite number of complex-float samples from a bladeRF 2.0."""
+
+    def __init__(
+        self,
+        file_length="100000",
+        filepath="",
+        ip_address="",
+        rx_antenna="",
+        rx_channel="",
+        rx_frequency="433.32",
+        rx_gain="50",
+        sample_rate="1",
+        serial="0",
+    ):
+        super().__init__("IQ Recorder bladeRF 2.0", catch_exceptions=True)
+
+        self.file_length = int(file_length)
+        self.filepath = str(filepath)
+        self.ip_address = str(ip_address)
+        self.rx_antenna = str(rx_antenna)
+        self.rx_channel = str(rx_channel)
+        self.rx_frequency = float(rx_frequency)
+        self.rx_gain = float(rx_gain)
+        self.sample_rate = float(sample_rate)
+        self.serial = str(serial)
+
+        device = "driver=bladerf"
+        device_args = "bladerf=" + self.serial
+        stream_args = ""
+        tune_args = [""]
+        settings = [""]
+
+        self.source = soapy.source(
+            device,
+            "fc32",
+            1,
+            device_args,
+            stream_args,
+            tune_args,
+            settings,
+        )
+        self.source.set_sample_rate(0, self.sample_rate * 1e6)
+        self.source.set_bandwidth(0, 0.0)
+        self.source.set_frequency(0, self.rx_frequency * 1e6)
+        self.source.set_frequency_correction(0, 0)
+        self.source.set_gain(0, min(max(self.rx_gain, -1.0), 60.0))
+
+        self.skiphead = blocks.skiphead(gr.sizeof_gr_complex, 200000)
+        self.head = blocks.head(gr.sizeof_gr_complex, self.file_length)
+        self.file_sink = blocks.file_sink(
+            gr.sizeof_gr_complex,
+            self.filepath,
+            False,
+        )
+        self.file_sink.set_unbuffered(False)
+
+        self.connect((self.source, 0), (self.skiphead, 0))
+        self.connect((self.skiphead, 0), (self.head, 0))
+        self.connect((self.head, 0), (self.file_sink, 0))

--- a/Plugins/Base/operations/iq_record.py
+++ b/Plugins/Base/operations/iq_record.py
@@ -5,8 +5,8 @@ IQ recorder operation for the Base plugin.
 
 Assumptions:
   - Artifact files are local/unpacked under FISSURE/artifacts/<operation_id>/files.
-  - B2x0/B20xmini record flow graph files are under:
-      Plugins/Base/flow_graphs/iq_record_flow_graphs/<maint-version>/b2x0/
+  - Hardware-specific record flow graphs are under:
+      Plugins/Base/flow_graphs/iq_record_flow_graphs/<maint-version>/<hardware>/
   - Zip transfer/download behavior is handled elsewhere.
 """
 
@@ -177,14 +177,21 @@ class OperationMain(Operation):
         if not self.artifact_manager:
             raise RuntimeError("iq_record requires artifact_manager to be passed in")
 
-        if self.flow_graph_name != "iq_recorder_b2x0":
+        supported_recorders = {
+            "iq_recorder_b2x0": {"USRP B20xmini", "USRP B2x0"},
+            "iq_recorder_bladerf2": {"bladeRF 2.0"},
+        }
+
+        compatible_hardware = supported_recorders.get(self.flow_graph_name)
+        if compatible_hardware is None:
             raise RuntimeError(
-                f"Unsupported IQ recorder flow graph for first pass: {self.flow_graph_name}"
+                f"Unsupported IQ recorder flow graph: {self.flow_graph_name}"
             )
 
-        if self.hardware_type not in {"USRP B20xmini", "USRP B2x0"}:
+        if self.hardware_type not in compatible_hardware:
             raise RuntimeError(
-                f"Unsupported IQ recording hardware for first pass: {self.hardware_type}"
+                f"IQ recorder {self.flow_graph_name} does not support "
+                f"hardware type {self.hardware_type}"
             )
 
         data_type_key = str(self.data_type or "").strip().lower()
@@ -379,7 +386,15 @@ class OperationMain(Operation):
 
     def _resolve_flow_graph_path(self) -> str:
         version = get_library_version() or "maint-3.10"
-        hardware_dir = "b2x0"
+        hardware_dirs = {
+            "iq_recorder_b2x0": "b2x0",
+            "iq_recorder_bladerf2": "bladerf2",
+        }
+        hardware_dir = hardware_dirs.get(self.flow_graph_name)
+        if hardware_dir is None:
+            raise RuntimeError(
+                f"No IQ recorder directory configured for {self.flow_graph_name}"
+            )
 
         path = os.path.join(
             PLUGIN_ROOT,

--- a/fissure/Dashboard/Slots/IQDataTabSlots.py
+++ b/fissure/Dashboard/Slots/IQDataTabSlots.py
@@ -442,6 +442,7 @@ def _slotIQ_RecordHardwareChanged(dashboard: QtCore.QObject):
         spinbox_frequency = QtWidgets.QDoubleSpinBox(dashboard)
         spinbox_frequency.setMaximum(6000)
         spinbox_frequency.setMinimum(47)
+        spinbox_frequency.setValue(433.32)
         spinbox_frequency.setAlignment(QtCore.Qt.AlignCenter)
         dashboard.ui.tableWidget_iq_record.setCellWidget(0,1,spinbox_frequency)
         comboBox_channel = QtWidgets.QComboBox(dashboard, objectName='comboBox2_')

--- a/fissure/Dashboard/Slots/IQDataTabSlots.py
+++ b/fissure/Dashboard/Slots/IQDataTabSlots.py
@@ -442,7 +442,6 @@ def _slotIQ_RecordHardwareChanged(dashboard: QtCore.QObject):
         spinbox_frequency = QtWidgets.QDoubleSpinBox(dashboard)
         spinbox_frequency.setMaximum(6000)
         spinbox_frequency.setMinimum(47)
-        spinbox_frequency.setValue(433.32)
         spinbox_frequency.setAlignment(QtCore.Qt.AlignCenter)
         dashboard.ui.tableWidget_iq_record.setCellWidget(0,1,spinbox_frequency)
         comboBox_channel = QtWidgets.QComboBox(dashboard, objectName='comboBox2_')


### PR DESCRIPTION
## Why this change is needed

The Base plugin currently exposes IQ recording only for USRP B20xmini/B2x0 hardware. A bladeRF 2.0 can be detected and assigned to a sensor node, but the IQ Record action does not advertise bladeRF support, the operation rejects the hardware/flowgraph pair, and there is no headless bladeRF recorder in the plugin flowgraph directory. The result is that recording cannot progress even though GNU Radio and Soapy can use the radio.

This was encountered with a Nuand bladeRF 2.0 compact/Mini-style device reported by libbladeRF as a bladerf2 board.

## What changed

- Advertise bladeRF 2.0 as supported by the Base IQ Record action.
- Add iq_recorder_bladerf2 to the action schema.
- Validate recorder/hardware compatibility using explicit mappings for B2x0 and bladeRF 2.0.
- Resolve recorder flowgraphs through hardware-specific directories.
- Add a GNU Radio 3.10 Soapy-based bladeRF 2.0 recorder that selects the radio by serial, configures frequency/sample rate/gain, skips startup samples, and writes a finite Complex Float 32 capture.

## Validation

- Tested on an actual remote bladeRF 2.0 sensor node at 433.32 MHz and 1 MS/s.
- Confirmed a 1,000,000-sample Complex Float 32 recording produced an 8,000,000-byte IQ artifact with populated hardware and capture metadata.

## Scope

This adds bladeRF 2.0 raw IQ capture support.