### PR TITLE
junk

### DIFF
--- a/Installer/deploy_remote_sensor_node.py
+++ b/Installer/deploy_remote_sensor_node.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Deploy and health-check a FISSURE sensor node with Apptainer and AsyncSSH.
+
+Usage:
+  deploy_remote_sensor_node.py <destination> [options]
+  deploy_remote_sensor_node.py --target=<destination> [options]
+  deploy_remote_sensor_node.py (-h | --help)
+
+Options:
+  -h --help                  Show this help.
+  --target=<destination>     Legacy [user@]IP form (default user: root).
+  -i <path> --identity=<path>  SSH private key; omit to enter a password.
+  --config=<path>            Remote YAML (default: installed Sensor Node YAML).
+  --certificates=<path>      Certificate root (default: installed certificates).
+  --image=<path>             Existing SIF to deploy instead of building.
+  --output-image=<path>      Local SIF output (default: repository build path).
+  --source=<path>            FISSURE source tree (default: repository root).
+  --build-with-sudo          Build with sudo instead of Apptainer fakeroot.
+  --no-install-apptainer     Do not install missing local or remote Apptainer.
+  --remote-dir=<path>        Installation root [default: /opt/fissure-sensor-node].
+  --service-name=<name>      systemd unit name [default: fissure-sensor-node].
+  --overlay-size=<mb>        Persistent overlay size [default: 4096].
+  --health-timeout=<seconds>  Health and heartbeat timeout [default: 75].
+  --startup-only             Do not require a HIPRFISR heartbeat.
+  --health-only              Check without changing the deployment.
+  --uninstall                Remove the remote service and deployment files.
+"""
+import asyncio
+from dataclasses import dataclass, replace
+import getpass
+import importlib
+import json
+from pathlib import Path
+import re
+import shlex
+import shutil
+import sys
+import tempfile
+import time
+from typing import Any, Mapping, Sequence
+import warnings
+
+from remote_sensor_node_deploy_utilities import DeploymentUtilities
+from remote_sensor_node_local_apptainer import (
+    LocalApptainerError,
+    ensure_local_apptainer,
+)
+from remote_sensor_node_config import ConfigPreparationError, prepare_remote_config
+from remote_sensor_node_uninstall import uninstall_remote
+from remote_sensor_node_privilege import (
+    PrivilegeContext,
+    PrivilegeError,
+    RemoteEnvironment,
+    prepare_remote_environment,
+    run_root_command,
+    run_root_script,
+)
+
+INSTALLER_DIR = Path(__file__).resolve().parent
+REPO_ROOT = INSTALLER_DIR.parent
+DEFINITION_FILE = INSTALLER_DIR / "remote_sensor_node_apptainer.def"
+REMOTE_DIR_PATTERN = re.compile(r"^/[A-Za-z0-9._/-]+$")
+SERVICE_PATTERN = re.compile(r"^[A-Za-z0-9_.@-]+$")
+
+
+class DeploymentError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class HostSpec:
+    hostname: str
+    username: str | None = None
+
+    @classmethod
+    def parse(cls, value: str) -> "HostSpec":
+        username, separator, hostname = value.rpartition("@")
+        if not separator:
+            hostname, username = value, "root"
+        hostname = hostname.strip("[]")
+        if not hostname or hostname.startswith("-") or "\n" in hostname:
+            raise DeploymentError(f"Invalid SSH target: {value!r}")
+        return cls(hostname, username or None)
+
+
+@dataclass(frozen=True)
+class DeployOptions:
+    target: HostSpec
+    identity_file: Path | None
+    config_file: Path
+    certificates_dir: Path
+    image_file: Path | None
+    output_image: Path
+    source_dir: Path
+    remote_dir: str
+    service_name: str
+    health_timeout: int
+    overlay_size_mb: int
+    startup_only: bool
+    health_only: bool
+    build_with_sudo: bool
+    install_apptainer: bool
+    uninstall: bool
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        options = parse_options(argv)
+        validate_options(options)
+        asyncssh = load_module("asyncssh")
+        asyncio.run(deploy(options, asyncssh))
+        return 0
+    except (
+        ConfigPreparationError,
+        DeploymentError,
+        LocalApptainerError,
+        PrivilegeError,
+    ) as exc:
+        print(f"[!] {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\n[!] Deployment interrupted", file=sys.stderr)
+        return 130
+
+
+async def deploy(options: DeployOptions, asyncssh: Any) -> None:
+    destination = f"{options.target.username}@{options.target.hostname}"
+    if options.uninstall:
+        password = prompt_for_ssh_password(options)
+        async with await connect(asyncssh, options, password) as connection:
+            await uninstall_remote(
+                connection,
+                destination,
+                options.remote_dir,
+                options.service_name,
+            )
+        return
+    if options.health_only:
+        password = prompt_for_ssh_password(options)
+        async with await connect(asyncssh, options, password) as connection:
+            environment = await preflight(connection, False, destination)
+            await wait_for_health(connection, options, environment.privilege)
+        return
+
+    with tempfile.TemporaryDirectory(prefix="fissure-node-deploy.") as name:
+        temp_dir = Path(name)
+        image = await get_image(options, temp_dir)
+        password = prompt_for_ssh_password(options)
+        async with await connect(asyncssh, options, password) as connection:
+            environment = await preflight(connection, options.install_apptainer, destination, )
+            config_file = prepare_remote_config(
+                options.config_file,
+                temp_dir / "default.yaml",
+                connection,
+            )
+            options = replace(options, config_file=config_file)
+            unit = temp_dir / f"{options.service_name}.service"
+            unit.write_text(build_service_unit(options, environment.user, environment.group, environment.apptainer))
+            await deploy_release(asyncssh, connection, options, image, unit, environment)
+
+
+def parse_options(argv: Sequence[str] | None = None) -> DeployOptions:
+    docopt = load_module("docopt").docopt
+    args = docopt(__doc__, argv=list(argv) if argv is not None else None)
+    return options_from_arguments(args)
+
+
+def options_from_arguments(args: Mapping[str, Any]) -> DeployOptions:
+    def path(name: str, default: Path | None = None) -> Path | None:
+        value = args[name]
+        return Path(value).expanduser() if value else default
+
+    def integer(name: str) -> int:
+        return int(args[name])
+
+    try:
+        source_dir = path("--source", REPO_ROOT) or REPO_ROOT
+        return DeployOptions(
+            target=HostSpec.parse(args["<destination>"] or args["--target"]),
+            identity_file=path("--identity"),
+            config_file=path("--config", source_dir / "YAML/Sensor_Node_Config/default.yaml"),
+            certificates_dir=path( "--certificates", source_dir / "certificates"),
+            image_file=path("--image"),
+            output_image=path("--output-image", source_dir / "build/fissure-sensor-node.sif"),
+            source_dir=source_dir,
+            remote_dir=args["--remote-dir"].rstrip("/") or "/",
+            service_name=args["--service-name"].removesuffix(".service"),
+            health_timeout=integer("--health-timeout"),
+            overlay_size_mb=integer("--overlay-size"),
+            startup_only=bool(args["--startup-only"]),
+            health_only=bool(args["--health-only"]),
+            build_with_sudo=bool(args["--build-with-sudo"]),
+            install_apptainer=not bool(args["--no-install-apptainer"]),
+            uninstall=bool(args["--uninstall"]),
+        )
+    except (TypeError, ValueError) as exc:
+        raise DeploymentError(f"Invalid numeric option: {exc}") from exc
+
+
+def validate_options(options: DeployOptions) -> None:
+    if not REMOTE_DIR_PATTERN.fullmatch(options.remote_dir):
+        raise DeploymentError("--remote-dir must be absolute and contain no spaces")
+    if options.remote_dir in {"/", "/opt"} or ".." in Path(options.remote_dir).parts:
+        raise DeploymentError("--remote-dir is too broad or contains '..'")
+    if not SERVICE_PATTERN.fullmatch(options.service_name):
+        raise DeploymentError("Invalid --service-name")
+    if options.health_timeout <= 0 or options.overlay_size_mb <= 0:
+        raise DeploymentError("Timeout and overlay size must be positive")
+    if options.health_only and options.uninstall:
+        raise DeploymentError("--health-only and --uninstall cannot be combined")
+    if options.identity_file and not options.identity_file.is_file():
+        raise DeploymentError(
+            f"SSH identity is not a file: {options.identity_file}"
+        )
+    local_inputs = []
+    if not options.health_only and not options.uninstall:
+        local_inputs += [
+            options.config_file,
+            options.certificates_dir / "clients/client_0.key_secret",
+            options.certificates_dir / "server/server.key",
+        ]
+        if options.image_file:
+            local_inputs.append(options.image_file)
+        else:
+            local_inputs += [DEFINITION_FILE, options.source_dir / "fissure/Sensor_Node"]
+    missing = [str(path) for path in local_inputs if path and not path.exists()]
+    if missing:
+        raise DeploymentError("Missing required input(s): " + ", ".join(missing))
+
+
+def prompt_for_ssh_password(options: DeployOptions) -> str | None:
+    if options.identity_file:
+        return None
+
+    username = f"{options.target.username}@" if options.target.username else ""
+    prompt = f"SSH password for {username}{options.target.hostname}: "
+    try:
+        # getpass otherwise falls back to echoed stdin when no secure terminal exists.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", getpass.GetPassWarning)
+            password = getpass.getpass(prompt)
+    except (EOFError, OSError, getpass.GetPassWarning) as exc:
+        raise DeploymentError(
+            "Unable to read an SSH password securely; use -i with a private key"
+        ) from exc
+    if not password:
+        raise DeploymentError("SSH password cannot be empty; use -i with a private key")
+    return password
+
+
+async def connect(
+    asyncssh: Any, options: DeployOptions, password: str | None
+) -> Any:
+    kwargs: dict[str, Any] = {"keepalive_interval": 30}
+    if options.target.username:
+        kwargs["username"] = options.target.username
+    if options.identity_file:
+        kwargs["client_keys"] = [str(options.identity_file)]
+    elif password:
+        kwargs.update(client_keys=None, password=password)
+    else:
+        raise DeploymentError("SSH password is required when -i is not specified")
+    try:
+        return await asyncssh.connect(options.target.hostname, **kwargs)
+    except (OSError, asyncssh.Error) as exc:
+        raise DeploymentError(f"SSH connection failed: {exc}") from exc
+
+
+async def preflight(connection: Any,install_apptainer: bool, destination: str) -> RemoteEnvironment:
+    try:
+        return await prepare_remote_environment(
+            connection,
+            destination,
+            install_apptainer,
+        )
+    except PrivilegeError as exc:
+        raise DeploymentError(str(exc)) from exc
+
+
+async def get_image(options: DeployOptions, temp_dir: Path) -> Path:
+    if options.image_file:
+        return options.image_file.resolve()
+    if options.output_image.is_file():
+        print(f"[✓] Using existing image {options.output_image}")
+        return options.output_image.resolve()
+    apptainer = await ensure_local_apptainer(options.install_apptainer)
+    source = temp_dir / "source"
+    await asyncio.to_thread(copy_build_context, options.source_dir, source)
+    definition = temp_dir / DEFINITION_FILE.name
+    definition.write_text(
+        DEFINITION_FILE.read_text().replace("__FISSURE_SOURCE__", str(source))
+    )
+    options.output_image.parent.mkdir(parents=True, exist_ok=True)
+    command = [apptainer, "build", "--force"]
+    command += ["--fakeroot"] if not options.build_with_sudo else []
+    command += [str(options.output_image), str(definition)]
+    if options.build_with_sudo:
+        command.insert(0, "sudo")
+    print(f"[*] Building {options.output_image}")
+    process = await asyncio.create_subprocess_exec(*command)
+    if await process.wait():
+        raise DeploymentError(f"Build failed: {shlex.join(command)}")
+    return options.output_image.resolve()
+
+
+def copy_build_context(source: Path, destination: Path) -> None:
+    root_exclusions = {
+        ".agents", ".codex", ".env", ".git", ".idea", ".venv",
+        "build", "certificates", "Logs",
+    }
+
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        ignored = {name for name in names if name in {".git", "__pycache__", ".pytest_cache"}}
+        if Path(directory).resolve() == source.resolve():
+            ignored.update(root_exclusions.intersection(names))
+        ignored.update(name for name in names if name.endswith(".key_secret"))
+        return ignored
+
+    shutil.copytree(source.resolve(), destination, symlinks=True, ignore=ignore)
+
+
+def build_service_unit(options: DeployOptions, user: str, group: str, apptainer: str) -> str:
+    root = options.remote_dir
+    home = f"{root}/state/home:/home/fissure"
+    overlay = f"{root}/state/runtime-overlay.img"
+    binds = (
+        f"--bind {root}/current/default.yaml:/opt/FISSURE/YAML/Sensor_Node_Config/default.yaml:ro "
+        f"--bind {root}/current/certificates:/opt/FISSURE/certificates:ro "
+        f"--bind {root}/state/logs:/opt/FISSURE/Logs --bind /run/udev:/run/udev:ro"
+    )
+    image = f"{root}/current/fissure-sensor-node.sif"
+    common = f"{apptainer} {{command}} --cleanenv --home {home} --overlay {overlay} {binds}"
+    check = common.format(command="exec") + (
+        f" {image} python3 "
+        "/opt/FISSURE/Installer/remote_sensor_node_image_check.py"
+    )
+    start = common.format(command="run") + (
+        " --env FISSURE_SENSOR_NODE_HEALTH_FILE="
+        f"/home/fissure/.fissure/sensor_node_health.json {image}"
+    )
+    return DeploymentUtilities.SERVICE_UNIT.format(
+        user=user, group=group, remote=root, check=check, start=start
+    )
+
+
+async def deploy_release(
+    asyncssh: Any,
+    connection: Any,
+    options: DeployOptions,
+    image: Path,
+    unit: Path,
+    environment: RemoteEnvironment,
+) -> None:
+    release_id = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    previous = (
+        await run_remote(
+            connection, f"readlink -f {shlex.quote(options.remote_dir + '/current')} || true",
+            check=False,
+        )
+    ).stdout.strip()
+    stage_result = await run_remote(connection, "mktemp -d /tmp/fissure-node-deploy.XXXXXX")
+    stage = stage_result.stdout.strip()
+    if not stage.startswith("/tmp/fissure-node-deploy."):
+        raise DeploymentError(f"Unexpected remote staging path: {stage}")
+    try:
+        await upload_payload(asyncssh, connection, stage, options, image, unit)
+        args = [
+            stage, options.remote_dir, release_id, options.service_name,
+            environment.user,
+            environment.group,
+            environment.apptainer,
+            str(options.overlay_size_mb),
+        ]
+        await run_root_script(connection, DeploymentUtilities.INSTALL_SCRIPT, args, environment.privilege)
+        await wait_for_health(connection, options, environment.privilege)
+    except Exception:
+        print("[!] Deployment failed; rolling back")
+        await run_root_script(
+            connection,
+            DeploymentUtilities.ROLLBACK_SCRIPT,
+            [options.remote_dir, options.service_name, previous],
+            environment.privilege,
+            check=False,
+        )
+        raise
+    print(f"[✓] Release {release_id} is active and healthy")
+
+
+async def upload_payload(asyncssh: Any, connection: Any, stage: str, options: DeployOptions, image: Path, unit: Path,
+) -> None:
+    files = {
+        image: "fissure-sensor-node.sif",
+        options.config_file: "default.yaml",
+        options.certificates_dir / "clients/client_0.key_secret": "client_0.key_secret",
+        options.certificates_dir / "server/server.key": "server.key",
+        unit: unit.name,
+    }
+    print(f"[*] Uploading {image.name} and runtime inputs with SCP")
+    try:
+        for local, remote_name in files.items():
+            await asyncssh.scp(str(local), (connection, f"{stage}/{remote_name}"))
+    except Exception as exc:
+        await run_remote(connection, f"rm -rf -- {shlex.quote(stage)}", check=False)
+        raise DeploymentError(f"SCP upload failed: {exc}") from exc
+
+
+async def wait_for_health(connection: Any, options: DeployOptions, privilege: PrivilegeContext) -> None:
+    deadline = time.monotonic() + options.health_timeout
+    health_file = f"{options.remote_dir}/state/home/.fissure/sensor_node_health.json"
+    while time.monotonic() < deadline:
+        state = (
+            await run_remote(
+                connection,
+                "systemctl is-active "
+                + shlex.quote(options.service_name + ".service"),
+                check=False,
+            )
+        ).stdout.strip()
+        result = await run_remote(connection, f"cat {shlex.quote(health_file)}", check=False)
+        if state == "active" and not result.exit_status:
+            try:
+                snapshot = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                snapshot = {}
+            if await health_is_ready(connection, snapshot, options):
+                print(f"[✓] Sensor node healthy: pid={snapshot['pid']}")
+                return
+        if state in {"failed", "inactive"}:
+            break
+        await asyncio.sleep(2)
+    journal = await run_root_command(
+        connection,
+        [
+            "journalctl",
+            "-u",
+            options.service_name + ".service",
+            "-n",
+            "80",
+            "--no-pager",
+        ],
+        privilege,
+        check=False,
+    )
+    print(journal.stdout, end="")
+    raise DeploymentError("Sensor node failed its health check")
+
+
+async def health_is_ready(connection: Any, snapshot: dict[str, Any], options: DeployOptions) -> bool:
+    pid = snapshot.get("pid")
+    if snapshot.get("status") != "running" or not isinstance(pid, int) or pid <= 0:
+        return False
+    process = await run_remote(
+        connection, f"kill -0 {pid} && tr '\\0' ' ' < /proc/{pid}/cmdline", check=False
+    )
+    if process.exit_status or "SensorNode.py" not in process.stdout:
+        return False
+    now = int((await run_remote(connection, "date +%s")).stdout.strip())
+    return heartbeat_is_ready(snapshot, now, options)
+
+
+def heartbeat_is_ready(snapshot: dict[str, Any], remote_now: int, options: DeployOptions) -> bool:
+    if options.startup_only or snapshot.get("network_type") != "IP":
+        return True
+    try:
+        age = remote_now - float(snapshot.get("updated_at_epoch", 0))
+    except (TypeError, ValueError):
+        return False
+    return bool(snapshot.get("hiprfisr_connected")) and 0 <= age <= options.health_timeout
+
+
+async def run_remote(connection: Any, command: str, check: bool = True, input_data: str | None = None) -> Any:
+    result = await connection.run(command, input=input_data, check=False)
+    if check and result.exit_status:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise DeploymentError(f"Remote command failed ({result.exit_status}): {detail}")
+    return result
+
+
+def load_module(name: str) -> Any:
+    try:
+        return importlib.import_module(name)
+    except ImportError as exc:
+        raise DeploymentError(
+            f"{name} is required. Install dependencies with: "
+            "python3 -m pip install -r Installer/requirements-node-deploy.txt"
+        ) from exc
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Installer/remote_sensor_node_apptainer.def
+++ b/Installer/remote_sensor_node_apptainer.def
@@ -1,0 +1,83 @@
+Bootstrap: docker
+From: ubuntu:24.04
+
+%labels
+    org.opencontainers.image.title FISSURE Remote Sensor Node
+    org.opencontainers.image.description Headless FISSURE remote sensor node
+    org.opencontainers.image.source https://github.com/ainfosec/FISSURE
+
+%help
+    FISSURE remote sensor-node image
+
+    Runtime configuration and CURVE keys must be bind-mounted at:
+      /opt/FISSURE/YAML/Sensor_Node_Config/default.yaml
+      /opt/FISSURE/certificates
+
+    Run the image with the repository deployment helper:
+      Installer/deploy_remote_sensor_node.py --target user@node ...
+
+%files
+    __FISSURE_SOURCE__/ /opt/FISSURE
+
+%environment
+    export PYTHONPATH=/opt/FISSURE:${PYTHONPATH:-}
+    export PYTHONUNBUFFERED=1
+    export MPLCONFIGDIR=${MPLCONFIGDIR:-/tmp/fissure-matplotlib}
+    export FISSURE_SENSOR_NODE_HEALTH_FILE=${FISSURE_SENSOR_NODE_HEALTH_FILE:-$HOME/.fissure/sensor_node_health.json}
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    # The FISSURE installer expects sudo even though Apptainer %post is root.
+    install -d /usr/local/bin
+    printf '#!/bin/sh\nexec "$@"\n' > /usr/local/bin/sudo
+    chmod 0755 /usr/local/bin/sudo
+
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        lsb-release \
+        python3 \
+        python3-crcmod \
+        python3-pip \
+        python3-setuptools \
+        xauth \
+        xvfb
+
+    # Ubuntu 24.04's installer upgrades setuptools before building legacy
+    # setup.py packages. Setuptools 81+ removes pkg_resources, which those
+    # packages still load, so constrain the entire installer subprocess.
+    printf 'setuptools<81\n' > /tmp/fissure-pip-constraints.txt
+    export PIP_CONSTRAINT=/tmp/fissure-pip-constraints.txt
+
+    cd /opt/FISSURE
+    chmod 0755 install
+    xvfb-run -a ./install --os "Ubuntu 24.04" --mode SensorNode
+    python3 -c "import pkg_resources, pydotplus"
+    rm -f /tmp/fissure-pip-constraints.txt
+
+    # Runtime keys are supplied by a read-only bind. Never ship build-host
+    # private material in the final SIF.
+    rm -rf /opt/FISSURE/certificates
+    install -d -m 0755 \
+        /opt/FISSURE/certificates/clients \
+        /opt/FISSURE/certificates/server \
+        /opt/FISSURE/Logs
+
+    # Sensor-node callbacks intentionally receive files and plugins. The SIF
+    # remains immutable; these permissions allow those writes into the
+    # deployment's private persistent overlay.
+    chmod -R a+rwX /opt/FISSURE
+
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+
+%runscript
+    cd /opt/FISSURE
+    exec xvfb-run -a python3 fissure/Sensor_Node/SensorNode.py "$@"
+
+%test
+    cd /opt/FISSURE
+    python3 Installer/remote_sensor_node_image_check.py \
+        --skip-certificates \
+        --allow-placeholder-config

--- a/Installer/remote_sensor_node_config.py
+++ b/Installer/remote_sensor_node_config.py
@@ -1,0 +1,76 @@
+"""Prepare the installed Sensor Node configuration for remote deployment."""
+
+from ipaddress import IPv4Address, ip_address
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+LOOPBACK_NAMES = {"", "ipc", "localhost"}
+
+
+class ConfigPreparationError(RuntimeError):
+    """Raised when a usable remote Sensor Node configuration cannot be made."""
+
+
+def prepare_remote_config(
+    source: Path,
+    destination: Path,
+    connection: Any,
+) -> Path:
+    config = _load_config(source)
+    node = config.get("Sensor Node")
+    if not isinstance(node, dict):
+        raise ConfigPreparationError("Sensor Node configuration is missing")
+
+    network_type = str(node.get("network_type", "")).strip()
+    configured_address = str(node.get("hiprfisr_ip_address", "")).strip()
+    if network_type != "IP" or _is_remote_address(configured_address):
+        return source
+
+    hub_address = _connection_ipv4_address(connection)
+    node["hiprfisr_ip_address"] = hub_address
+    destination.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    destination.chmod(0o600)
+    print(f"[*] Staged Sensor Node config uses HIPRFISR address {hub_address}")
+    return destination
+
+
+def _load_config(source: Path) -> dict[str, Any]:
+    try:
+        with source.open(encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file)
+    except (OSError, yaml.YAMLError) as exc:
+        raise ConfigPreparationError(f"Unable to read Sensor Node YAML: {exc}") from exc
+    if not isinstance(config, dict):
+        raise ConfigPreparationError("Sensor Node YAML must contain a mapping")
+    return config
+
+
+def _is_remote_address(value: str) -> bool:
+    if value.lower() in LOOPBACK_NAMES:
+        return False
+    try:
+        address = ip_address(value)
+    except ValueError:
+        return True
+    return not (address.is_loopback or address.is_unspecified)
+
+
+def _connection_ipv4_address(connection: Any) -> str:
+    sockname = connection.get_extra_info("sockname")
+    if not isinstance(sockname, (tuple, list)) or not sockname:
+        raise ConfigPreparationError("SSH connection did not report its local address")
+
+    try:
+        address = ip_address(str(sockname[0]))
+    except ValueError as exc:
+        raise ConfigPreparationError(
+            f"SSH connection reported an invalid local address: {sockname[0]!r}"
+        ) from exc
+    if not isinstance(address, IPv4Address) or address.is_loopback or address.is_unspecified:
+        raise ConfigPreparationError(
+            "Could not derive a reachable IPv4 HIPRFISR address; use --config"
+        )
+    return str(address)

--- a/Installer/remote_sensor_node_deploy_utilities.py
+++ b/Installer/remote_sensor_node_deploy_utilities.py
@@ -1,0 +1,162 @@
+"""Systemd and remote-shell templates used by the sensor-node deployer."""
+
+
+class DeploymentUtilities:
+    """Templates executed or installed on the remote sensor node."""
+
+    SERVICE_UNIT = """\
+[Unit]
+Description=FISSURE Remote Sensor Node (Apptainer)
+Wants=network-online.target
+After=network-online.target
+[Service]
+Type=simple
+User={user}
+Group={group}
+WorkingDirectory={remote}
+UMask=0077
+Environment=HOME=/home/fissure
+ExecStartPre={check}
+ExecStart={start}
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+KillMode=mixed
+LimitMEMLOCK=infinity
+[Install]
+WantedBy=multi-user.target
+"""
+
+    PREFLIGHT_SCRIPT = """\
+set -eu
+command -v systemctl >/dev/null || { echo "systemd is unavailable" >&2; exit 11; }
+test -d /run/udev || { echo "/run/udev is unavailable" >&2; exit 13; }
+if [ "$(id -u)" -eq 0 ]; then
+  privilege=root
+else
+  command -v sudo >/dev/null || { echo "sudo is required" >&2; exit 12; }
+  command -v runuser >/dev/null || { echo "runuser is required" >&2; exit 14; }
+  if sudo -n true >/dev/null 2>&1; then
+    privilege=passwordless
+  else
+    privilege=password
+  fi
+fi
+printf '%s|%s|%s|%s\\n' \
+  "$(id -un)" "$(id -gn)" "$(command -v apptainer || true)" "$privilege"
+"""
+
+    UNINSTALL_PREFLIGHT_SCRIPT = """\
+set -eu
+command -v systemctl >/dev/null || { echo "systemd is unavailable" >&2; exit 11; }
+if [ "$(id -u)" -eq 0 ]; then
+  privilege=root
+else
+  command -v sudo >/dev/null || { echo "sudo is required" >&2; exit 12; }
+  if sudo -n true >/dev/null 2>&1; then
+    privilege=passwordless
+  else
+    privilege=password
+  fi
+fi
+printf '%s\\n' "$privilege"
+"""
+
+    INSTALL_APPTAINER_SCRIPT = """\
+set -eu
+. /etc/os-release
+case " ${ID:-} ${ID_LIKE:-} " in
+  *" ubuntu "*) ;;
+  *)
+    echo "Automatic Apptainer installation supports Ubuntu-derived systems only" >&2
+    exit 20
+    ;;
+esac
+architecture=$(dpkg --print-architecture)
+case "$architecture" in
+  amd64|arm64) ;;
+  *)
+    echo "Automatic Apptainer installation does not support $architecture" >&2
+    exit 21
+    ;;
+esac
+# The signed Apptainer PPA tracks supported Ubuntu releases and architectures.
+apt-get update
+env DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+add-apt-repository -y ppa:apptainer/ppa
+apt-get update
+env DEBIAN_FRONTEND=noninteractive apt-get install -y apptainer
+apptainer version >/dev/null
+"""
+
+    INSTALL_SCRIPT = """\
+set -eu
+stage=$1; root=$2; release_id=$3; service=$4
+user=$5; group=$6; apptainer=$7; overlay_size=$8
+release="$root/releases/$release_id"; state="$root/state"
+health="$state/home/.fissure/sensor_node_health.json"
+trap 'rm -rf -- "$stage"' EXIT
+as_service() {
+  if [ "$user" = root ]; then "$@"; else runuser -u "$user" -- "$@"; fi
+}
+install -d -m 0755 "$root" "$root/releases"
+install -d -o "$user" -g "$group" -m 0700 \
+  "$release" "$release/certificates" "$release/certificates/clients" \
+  "$release/certificates/server" "$state" "$state/home" "$state/logs"
+install -o "$user" -g "$group" -m 0444 \
+  "$stage/fissure-sensor-node.sif" "$release/fissure-sensor-node.sif"
+install -o "$user" -g "$group" -m 0440 \
+  "$stage/default.yaml" "$release/default.yaml"
+install -o "$user" -g "$group" -m 0400 \
+  "$stage/client_0.key_secret" "$release/certificates/clients/client_0.key_secret"
+install -o "$user" -g "$group" -m 0444 \
+  "$stage/server.key" "$release/certificates/server/server.key"
+as_service "$apptainer" exec --cleanenv \
+  --home "$state/home:/home/fissure" \
+  --bind "$release/default.yaml:/opt/FISSURE/YAML/Sensor_Node_Config/default.yaml:ro" \
+  --bind "$release/certificates:/opt/FISSURE/certificates:ro" \
+  "$release/fissure-sensor-node.sif" \
+  python3 /opt/FISSURE/Installer/remote_sensor_node_image_check.py
+if [ ! -f "$state/runtime-overlay.img" ]; then
+  as_service "$apptainer" overlay create \
+    --size "$overlay_size" "$state/runtime-overlay.img"
+  chmod 0600 "$state/runtime-overlay.img"
+fi
+install -o root -g root -m 0644 \
+  "$stage/$service.service" "/etc/systemd/system/$service.service"
+systemctl stop "$service.service" >/dev/null 2>&1 || true
+[ ! -f "$health" ] || mv "$health" "$health.previous.$release_id"
+link="$root/current.$release_id"
+ln -s "$release" "$link"
+mv -Tf "$link" "$root/current"
+systemctl daemon-reload
+systemctl enable "$service.service" >/dev/null
+systemctl start "$service.service"
+"""
+
+    ROLLBACK_SCRIPT = """\
+set -eu
+root=$1; service=$2; previous=$3
+health="$root/state/home/.fissure/sensor_node_health.json"
+systemctl stop "$service.service" >/dev/null 2>&1 || true
+[ ! -f "$health" ] || mv "$health" "$health.failed.$(date -u +%Y%m%dT%H%M%SZ)"
+if [ -n "$previous" ] && [ -d "$previous" ]; then
+  link="$root/current.rollback.$$"
+  ln -s "$previous" "$link"
+  mv -Tf "$link" "$root/current"
+  systemctl start "$service.service"
+else
+  systemctl disable "$service.service" >/dev/null 2>&1 || true
+fi
+"""
+
+    UNINSTALL_SCRIPT = """\
+set -eu
+root=$1; service=$2
+unit="/etc/systemd/system/$service.service"
+systemctl disable --now "$service.service" >/dev/null 2>&1 || true
+rm -f -- "$unit"
+systemctl daemon-reload
+systemctl reset-failed "$service.service" >/dev/null 2>&1 || true
+rm -rf --one-file-system -- "$root"
+"""

--- a/Installer/remote_sensor_node_image_check.py
+++ b/Installer/remote_sensor_node_image_check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate a FISSURE remote sensor-node image and its runtime inputs."""
+
+import argparse
+import importlib
+import os
+from pathlib import Path
+import shutil
+import sys
+
+import yaml
+import zmq.auth
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = PROJECT_ROOT / "YAML" / "Sensor_Node_Config" / "default.yaml"
+DEFAULT_CERTIFICATES = PROJECT_ROOT / "certificates"
+XVFB_ACTIVE_ENV = "FISSURE_XVFB_ACTIVE"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--certificates", type=Path, default=DEFAULT_CERTIFICATES)
+    parser.add_argument("--skip-certificates", action="store_true")
+    parser.add_argument("--skip-runtime-import", action="store_true")
+    parser.add_argument("--allow-placeholder-config", action="store_true")
+    return parser.parse_args()
+
+
+def ensure_apptainer_display():
+    in_apptainer = os.getenv("APPTAINER_CONTAINER") or os.getenv("APPTAINER_NAME")
+    if not in_apptainer or os.getenv(XVFB_ACTIVE_ENV) == "1":
+        return
+
+    xvfb_run = shutil.which("xvfb-run")
+    if not xvfb_run:
+        raise RuntimeError("xvfb-run is required for headless Apptainer validation")
+
+    # Apptainer can inherit an unusable host DISPLAY. Always create an isolated
+    # virtual display so Dashboard imports cannot depend on host X credentials.
+    environment = os.environ.copy()
+    environment[XVFB_ACTIVE_ENV] = "1"
+    os.execve(
+        xvfb_run,
+        [xvfb_run, "-a", sys.executable, *sys.argv],
+        environment,
+    )
+
+
+def validate_config(config_path, allow_placeholder_config=False):
+    with config_path.open(encoding="utf-8") as config_file:
+        config = yaml.safe_load(config_file)
+
+    if not isinstance(config, dict) or not isinstance(config.get("Sensor Node"), dict):
+        raise ValueError("config must contain a 'Sensor Node' mapping")
+
+    node = config["Sensor Node"]
+    network_type = str(node.get("network_type", "")).strip()
+    if network_type not in {"IP", "Meshtastic"}:
+        raise ValueError("Sensor Node.network_type must be IP or Meshtastic")
+
+    nickname = str(node.get("nickname", "")).strip()
+    if not nickname or nickname == "Local Sensor Node":
+        raise ValueError("remote sensor-node nickname must be non-empty and not 'Local Sensor Node'")
+
+    if network_type == "IP":
+        hiprfisr_address = str(node.get("hiprfisr_ip_address", "")).strip()
+        if not hiprfisr_address:
+            raise ValueError("Sensor Node.hiprfisr_ip_address must not be empty")
+        if (
+            not allow_placeholder_config
+            and hiprfisr_address in {"ipc", "127.0.0.1", "localhost"}
+        ):
+            raise ValueError(
+                "an IP remote node needs a non-loopback Sensor Node.hiprfisr_ip_address"
+            )
+
+        for field in ("hb_port", "msg_port"):
+            port = int(node.get(field, 0))
+            if not 1 <= port <= 65535:
+                raise ValueError(f"Sensor Node.{field} must be a valid TCP port")
+    else:
+        serial_port = str(node.get("meshtastic_serial_port", "")).strip()
+        if not serial_port.startswith("/dev/"):
+            raise ValueError("Meshtastic nodes need an absolute /dev serial port")
+
+    return network_type
+
+
+def validate_certificates(certificates_path):
+    required = (
+        certificates_path / "clients" / "client_0.key_secret",
+        certificates_path / "server" / "server.key",
+    )
+    for certificate in required:
+        if not certificate.is_file():
+            raise FileNotFoundError(f"missing required certificate: {certificate}")
+        zmq.auth.load_certificate(str(certificate))
+
+    private_mode = required[0].stat().st_mode & 0o777
+    if private_mode & 0o077:
+        raise PermissionError(
+            f"{required[0]} must not be accessible by group or other users "
+            f"(current mode: {private_mode:o})"
+        )
+
+
+def main():
+    args = parse_args()
+    network_type = validate_config(args.config, args.allow_placeholder_config)
+
+    if network_type == "IP" and not args.skip_certificates:
+        validate_certificates(args.certificates)
+
+    if not args.skip_runtime_import:
+        sys.path.insert(0, str(PROJECT_ROOT))
+        importlib.import_module("fissure.Sensor_Node.SensorNode")
+
+    certificate_result = (
+        "skipped"
+        if args.skip_certificates or network_type != "IP"
+        else "valid"
+    )
+    print(
+        "FISSURE remote sensor-node image check passed "
+        f"(network={network_type}, certificates={certificate_result})"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        ensure_apptainer_display()
+        main()
+    except Exception as exc:
+        print(f"FISSURE remote sensor-node image check failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/Installer/remote_sensor_node_local_apptainer.py
+++ b/Installer/remote_sensor_node_local_apptainer.py
@@ -1,0 +1,41 @@
+"""Install the local Apptainer prerequisite before remote deployment."""
+
+import asyncio
+import os
+import shutil
+
+from remote_sensor_node_deploy_utilities import DeploymentUtilities
+
+
+class LocalApptainerError(RuntimeError):
+    """Raised when the local Apptainer prerequisite cannot be prepared."""
+
+
+async def ensure_local_apptainer(allow_install: bool) -> str:
+    """Return the local binary, installing it when permitted and necessary."""
+    apptainer = shutil.which("apptainer")
+    if apptainer:
+        return apptainer
+    if not allow_install:
+        raise LocalApptainerError("Apptainer is not installed locally")
+
+    command = ["bash", "-c", DeploymentUtilities.INSTALL_APPTAINER_SCRIPT]
+    if os.geteuid() != 0:
+        sudo = shutil.which("sudo")
+        if not sudo:
+            raise LocalApptainerError(
+                "sudo is required to install Apptainer locally"
+            )
+        command.insert(0, sudo)
+
+    print("[*] Apptainer is missing locally; installing it from the official PPA")
+    process = await asyncio.create_subprocess_exec(*command)
+    if await process.wait():
+        raise LocalApptainerError("Local Apptainer installation failed")
+
+    apptainer = shutil.which("apptainer")
+    if not apptainer:
+        raise LocalApptainerError(
+            "Local Apptainer installation did not provide a binary"
+        )
+    return apptainer

--- a/Installer/remote_sensor_node_privilege.py
+++ b/Installer/remote_sensor_node_privilege.py
@@ -1,0 +1,188 @@
+"""Secure privilege acquisition and remote prerequisite bootstrap."""
+
+from dataclasses import dataclass, field
+import getpass
+import shlex
+from typing import Any
+import warnings
+
+from remote_sensor_node_deploy_utilities import DeploymentUtilities
+
+
+class PrivilegeError(RuntimeError):
+    """Raised when remote privilege or prerequisite setup fails."""
+
+
+@dataclass(frozen=True)
+class PrivilegeContext:
+    """Credentials needed to execute remote commands as root."""
+
+    mode: str
+    password: str | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class RemoteEnvironment:
+    """Validated remote account and runtime paths."""
+
+    user: str
+    group: str
+    apptainer: str
+    privilege: PrivilegeContext
+
+
+async def prepare_remote_environment(
+    connection: Any,
+    destination: str,
+    install_apptainer: bool,
+) -> RemoteEnvironment:
+    """Validate privilege and install Apptainer when allowed and necessary."""
+    result = await _run(connection, DeploymentUtilities.PREFLIGHT_SCRIPT)
+    user, group, apptainer, mode = _parse_preflight(result.stdout)
+    privilege = await _acquire_privilege(connection, destination, mode)
+
+    if not apptainer:
+        if not install_apptainer:
+            raise PrivilegeError("Apptainer is not installed on the remote host")
+        print("[*] Apptainer is missing; installing it from the official PPA")
+        await run_root_script(
+            connection,
+            DeploymentUtilities.INSTALL_APPTAINER_SCRIPT,
+            [],
+            privilege,
+        )
+        apptainer = (
+            await _run(connection, "command -v apptainer")
+        ).stdout.strip()
+        if not apptainer:
+            raise PrivilegeError("Apptainer installation did not provide a binary")
+
+    print(f"[✓] Remote prerequisites passed ({user}, {apptainer})")
+    return RemoteEnvironment(user, group, apptainer, privilege)
+
+
+async def prepare_uninstall_privilege(
+    connection: Any,
+    destination: str,
+) -> PrivilegeContext:
+    """Acquire only the privilege needed to remove a deployment."""
+    result = await _run(connection, DeploymentUtilities.UNINSTALL_PREFLIGHT_SCRIPT)
+    mode = result.stdout.strip()
+    if mode not in {"root", "passwordless", "password"}:
+        raise PrivilegeError("Unable to read remote privilege information")
+    return await _acquire_privilege(connection, destination, mode)
+
+
+async def run_root_command(
+    connection: Any,
+    args: list[str],
+    privilege: PrivilegeContext,
+    check: bool = True,
+) -> Any:
+    """Execute one argument-safe command with remote root privilege."""
+    command = shlex.join(
+        [
+            "bash",
+            "-c",
+            'exec </dev/null; exec "$@"',
+            "fissure-root-command",
+            *args,
+        ]
+    )
+    return await _run_as_root(
+        connection,
+        command,
+        privilege,
+        check,
+    )
+
+
+async def run_root_script(
+    connection: Any,
+    script: str,
+    args: list[str],
+    privilege: PrivilegeContext,
+    check: bool = True,
+) -> Any:
+    """Execute a static script as root without placing credentials in arguments."""
+    secured_script = "exec </dev/null\n" + script
+    command = shlex.join(
+        ["bash", "-c", secured_script, "fissure-deploy", *args]
+    )
+    return await _run_as_root(connection, command, privilege, check)
+
+
+async def _acquire_privilege(
+    connection: Any,
+    destination: str,
+    mode: str,
+) -> PrivilegeContext:
+    if mode == "root":
+        return PrivilegeContext(mode)
+    if mode == "passwordless":
+        return PrivilegeContext(mode)
+    if mode != "password":
+        raise PrivilegeError(f"Unsupported remote privilege mode: {mode!r}")
+
+    # Privilege is acquired before concurrent deployment work begins.
+    password = _prompt_sudo_password(destination)
+    privilege = PrivilegeContext(mode, password)
+    try:
+        await run_root_command(connection, ["true"], privilege)
+    except PrivilegeError as exc:
+        raise PrivilegeError("Remote sudo authentication failed") from exc
+    return privilege
+
+
+def _prompt_sudo_password(destination: str) -> str:
+    try:
+        # Refuse getpass's echoed-input fallback to avoid exposing credentials.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", getpass.GetPassWarning)
+            password = getpass.getpass(f"Sudo password for {destination}: ")
+    except (EOFError, OSError, getpass.GetPassWarning) as exc:
+        raise PrivilegeError("Unable to read the sudo password securely") from exc
+    if not password:
+        raise PrivilegeError("Sudo password cannot be empty")
+    return password
+
+
+async def _run_as_root(
+    connection: Any,
+    command: str,
+    privilege: PrivilegeContext,
+    check: bool,
+) -> Any:
+    input_data = None
+    if privilege.mode == "root":
+        privileged_command = command
+    elif privilege.password is None:
+        privileged_command = f"sudo -n -- {command}"
+    else:
+        # Invalidate cached credentials so sudo always consumes password stdin.
+        privileged_command = f"sudo -k -S -p '' -- {command}"
+        input_data = privilege.password + "\n"
+    return await _run(connection, privileged_command, check, input_data)
+
+
+async def _run(
+    connection: Any,
+    command: str,
+    check: bool = True,
+    input_data: str | None = None,
+) -> Any:
+    result = await connection.run(command, input=input_data, check=False)
+    if check and result.exit_status:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise PrivilegeError(
+            f"Remote command failed ({result.exit_status}): {detail}"
+        )
+    return result
+
+
+def _parse_preflight(stdout: str) -> tuple[str, str, str, str]:
+    try:
+        user, group, apptainer, mode = stdout.strip().split("|", 3)
+    except ValueError as exc:
+        raise PrivilegeError("Unable to read remote account information") from exc
+    return user, group, apptainer, mode

--- a/Installer/remote_sensor_node_uninstall.py
+++ b/Installer/remote_sensor_node_uninstall.py
@@ -1,0 +1,25 @@
+"""Remove a remote FISSURE Sensor Node deployment without removing Apptainer."""
+
+from typing import Any
+
+from remote_sensor_node_deploy_utilities import DeploymentUtilities
+from remote_sensor_node_privilege import (
+    prepare_uninstall_privilege,
+    run_root_script,
+)
+
+
+async def uninstall_remote(
+    connection: Any,
+    destination: str,
+    remote_dir: str,
+    service_name: str,
+) -> None:
+    privilege = await prepare_uninstall_privilege(connection, destination)
+    await run_root_script(
+        connection,
+        DeploymentUtilities.UNINSTALL_SCRIPT,
+        [remote_dir, service_name],
+        privilege,
+    )
+    print(f"[✓] Removed {service_name}.service and {remote_dir}")

--- a/Installer/requirements-node-deploy.txt
+++ b/Installer/requirements-node-deploy.txt
@@ -1,0 +1,3 @@
+asyncssh>=2.24.0,<3
+docopt-ng>=0.9.0,<1
+PyYAML>=6,<7

--- a/README.md
+++ b/README.md
@@ -407,7 +407,88 @@ Install FISSURE per usual on a general purpose computer. Install FISSURE on the 
 
 Change the "autorun" field from from `false` to `true` to run the default autorun playlist file on startup and forgo remote operations. New autorun playlists can be generated and saved from the Dashboard Autorun tab.
 
-The remote sensor node acts as a server and must have a set of valid certificates (generated during install) that match with the client (local computer). The server needs the "server.key_secret" and "client.key" files while the client needs the "client.key_secret" and "server.key" files. If the certificates folder was generated on the server computer, the client files must be manually transferred to the other computer.
+An IP remote sensor node connects to HIPRFISR as a CURVE client. It needs the matching `certificates/clients/client_0.key_secret` and `certificates/server/server.key` files. Keep the private key out of source control and readable only by the sensor-node service account.
+
+**Apptainer Remote Sensor Node Deployment**
+
+The dedicated Apptainer deployment packages the headless `SensorNode` install, transfers it with SCP over AsyncSSH, installs it as a systemd service, and verifies both process health and a fresh heartbeat from HIPRFISR. Runtime configuration, certificates, logs, node UUID, and the writable overlay remain outside the SIF so upgrades preserve node identity and do not bake keys into the image.
+
+Prerequisites:
+
+- Apptainer on the build computer (or pass an existing SIF with `--image`).
+- Python 3.10 or newer with the deployer's AsyncSSH and docopt dependencies.
+- SSH access to the remote node and `sudo` permission for installing/managing
+  its system service.
+- The current FISSURE installation's Sensor Node YAML, already configured with
+  the desired remote nickname and HIPRFISR address.
+- Installed certificates containing `clients/client_0.key_secret` and
+  `server/server.key`.
+
+Install the Python deployment dependencies:
+
+```
+python3 -m pip install -r Installer/requirements-node-deploy.txt
+```
+
+For the basic installation, provide only the remote IP. The deployer assumes
+the `root` SSH account and securely prompts for its password:
+
+```
+Installer/deploy_remote_sensor_node.py 192.0.2.20
+```
+
+The deployer uses `YAML/Sensor_Node_Config/default.yaml` exactly as installed
+and selects the installed
+`certificates/clients/client_0.key_secret` and
+`certificates/server/server.key`. It performs no address discovery and does not
+modify the installed YAML or certificates.
+
+Before opening SSH, a full deployment uses the existing
+`build/fissure-sensor-node.sif` or builds it locally when it does not exist.
+Pass `--image /path/to/image.sif` to select a different existing image.
+If the local Apptainer executable is also missing, the deployer first installs
+it from the official PPA and then builds the SIF. Local `sudo` may prompt in
+the terminal during this step.
+
+If Apptainer is missing remotely, a full deployment installs it from the
+official Apptainer PPA on Ubuntu-derived `amd64` or `arm64` systems. This
+requires remote internet access and adds the PPA before installing the
+`apptainer` package. Use `--no-install-apptainer` to disable local and remote
+package changes;
+unsupported systems fail with a manual-install message. A `--health-only`
+check never installs packages.
+
+Add `-i ~/.ssh/sensor-node` to use a private key instead of a password. Use an
+explicit `user@host`, `--config`, or `--certificates` to override the basic
+defaults. To deploy an existing image, add
+`--image /path/to/fissure-sensor-node.sif`.
+
+When connecting as a non-root user, the deployer first tries passwordless
+`sudo`. If it is unavailable, it securely prompts once for the sudo password,
+validates it, and reuses it for privileged package, installation, health, and
+rollback commands. The password is sent only over SSH standard input; it is
+not placed in command arguments or remote files. Direct root SSH does not
+invoke `sudo`.
+
+To check a running deployment again without changing it:
+
+```
+Installer/deploy_remote_sensor_node.py 192.0.2.20 --health-only
+```
+
+To stop the remote service and remove its SIF, configuration, certificates,
+logs, overlay, and persistent state:
+
+```
+Installer/deploy_remote_sensor_node.py 192.0.2.20 --uninstall
+```
+
+Uninstall uses the same SSH key/password and sudo handling as deployment. It
+does not remove the remote Apptainer package or the local
+`build/fissure-sensor-node.sif`, so running the basic installation command
+again reuses the existing local image.
+
+Use `-i`/`--identity` to select a private key explicitly. If it is omitted, the deployer securely prompts once for the SSH password and reuses it if deployment requires a second connection. AsyncSSH continues to apply normal OpenSSH configuration and known-hosts checks. The default health check waits for a fresh HIPRFISR heartbeat and rolls back a failed upgrade. Use `--startup-only` only when intentionally staging a node without a reachable hub. Run the script with `--help` for paths, overlay sizing, and other deployment settings.
 
 **Local Dashboard Usage**
 

--- a/fissure/Sensor_Node/SensorNode.py
+++ b/fissure/Sensor_Node/SensorNode.py
@@ -173,8 +173,8 @@ async def main(local_flag):
         if not local_flag:
             fissure.utils.zmq_cleanup()
 
+        sensor_node.write_health_status("stopped")
         print("[FISSURE][Sensor Node] end")
-        return
 
 
 class SensorNode(object):
@@ -324,6 +324,46 @@ class SensorNode(object):
             asyncio.create_task(self._notify_hiprfisr_of_artifact(artifact_id))
             return artifact_id
         self.artifact_manager.create_artifact = create_artifact_wrapper
+        self.write_health_status("starting")
+
+
+    def write_health_status(self, status: str, error: Optional[str] = None):
+        """Publish an atomic, machine-readable sensor-node health snapshot."""
+        health_path = os.environ.get(
+            "FISSURE_SENSOR_NODE_HEALTH_FILE",
+            os.path.expanduser("~/.fissure/sensor_node_health.json"),
+        )
+        heartbeat_time = self.heartbeats.get(
+            fissure.comms.Identifiers.HIPRFISR, 0.0
+        )
+        payload = {
+            "status": status,
+            "updated_at_epoch": time.time(),
+            "pid": os.getpid(),
+            "node_uuid": self.uuid,
+            "nickname": self.settings_dict.get("Sensor Node", {}).get("nickname", ""),
+            "network_type": self.network_type,
+            "hiprfisr_ip_address": self.hiprfisr_ip_address,
+            "hiprfisr_connected": bool(heartbeat_time),
+            "last_hiprfisr_heartbeat": heartbeat_time or None,
+        }
+        if error:
+            payload["error"] = error
+
+        temp_path = f"{health_path}.{os.getpid()}.tmp"
+        try:
+            os.makedirs(os.path.dirname(health_path) or ".", exist_ok=True)
+            with open(temp_path, "w") as health_file:
+                json.dump(payload, health_file, sort_keys=True)
+                health_file.write("\n")
+            os.replace(temp_path, health_path)
+        except Exception as exc:
+            try:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+            except OSError:
+                pass
+            self.logger.warning(f"Unable to publish sensor-node health: {exc}")
 
 
     async def initialize_comms(self):
@@ -338,8 +378,8 @@ class SensorNode(object):
             self.hiprfisr_address = fissure.comms.Address(
                 protocol=network_protocol,
                 address=self.hiprfisr_ip_address,
-                hb_channel=6100,  # TODO: pull from YAML anyway in case default is changed
-                msg_channel=6101,
+                hb_channel=int(self.settings_dict["Sensor Node"].get("hb_port", 6100)),
+                msg_channel=int(self.settings_dict["Sensor Node"].get("msg_port", 6101)),
             )
 
             # Single DEALER exactly like PD/TSI
@@ -1385,6 +1425,7 @@ class SensorNode(object):
         if heartbeat is not None:
             heartbeat_time = float(heartbeat.get(fissure.comms.MessageFields.TIME))
             self.heartbeats[fissure.comms.Identifiers.HIPRFISR] = heartbeat_time
+            self.write_health_status("running")
             self.logger.debug(f"received HiprFisr heartbeat ({fissure.utils.get_timestamp(heartbeat_time)})")
 
 
@@ -1404,6 +1445,7 @@ class SensorNode(object):
                 await asyncio.sleep(0.1)  # For ZMQ handshake to complete
             else:
                 self.logger.error("FAILED connecting to HIPRFISR")
+                self.write_health_status("failed", "FAILED connecting to HIPRFISR")
                 return
         elif self.network_type == "Meshtastic":
             try:
@@ -1420,10 +1462,14 @@ class SensorNode(object):
                 self.logger.error(
                     f"Failed to initialize Meshtastic on {serial_port}: {e}"
                 )
+                self.write_health_status("failed", str(e))
                 return
         else:
             self.logger.error("Unknown network type. Enter IP or Meshtastic in node YAML config file.")
+            self.write_health_status("failed", "Unknown network type")
             return
+
+        self.write_health_status("running")
         
         # Start Heartbeat Loop
         heartbeat_task = asyncio.create_task(self.heartbeat_loop())

--- a/tests/test_remote_sensor_node_config.py
+++ b/tests/test_remote_sensor_node_config.py
@@ -1,0 +1,102 @@
+"""Tests for staging the installed Sensor Node configuration."""
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+
+INSTALLER_DIR = Path(__file__).resolve().parents[1] / "Installer"
+sys.path.insert(0, str(INSTALLER_DIR))
+
+from remote_sensor_node_config import (  # noqa: E402
+    ConfigPreparationError,
+    prepare_remote_config,
+)
+
+
+class FakeConnection:
+    def __init__(self, local_address):
+        self.local_address = local_address
+
+    def get_extra_info(self, name):
+        return (self.local_address, 54321) if name == "sockname" else None
+
+
+class RemoteSensorNodeConfigTests(unittest.TestCase):
+    def test_replaces_loopback_in_staged_copy(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            source, staged = root / "source.yaml", root / "staged.yaml"
+            source.write_text(
+                yaml.safe_dump(
+                    {
+                        "Sensor Node": {
+                            "network_type": "IP",
+                            "hiprfisr_ip_address": "127.0.0.1",
+                        }
+                    }
+                )
+            )
+
+            result = prepare_remote_config(
+                source,
+                staged,
+                FakeConnection("192.168.187.10"),
+            )
+
+            config = yaml.safe_load(result.read_text())
+            self.assertEqual(
+                config["Sensor Node"]["hiprfisr_ip_address"],
+                "192.168.187.10",
+            )
+            self.assertIn("127.0.0.1", source.read_text())
+
+    def test_preserves_explicit_remote_address(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            source = Path(temp_name) / "source.yaml"
+            source.write_text(
+                yaml.safe_dump(
+                    {
+                        "Sensor Node": {
+                            "network_type": "IP",
+                            "hiprfisr_ip_address": "10.20.30.40",
+                        }
+                    }
+                )
+            )
+
+            result = prepare_remote_config(
+                source,
+                Path(temp_name) / "staged.yaml",
+                FakeConnection("192.168.187.10"),
+            )
+
+            self.assertEqual(result, source)
+
+    def test_rejects_unusable_connection_address(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            source = Path(temp_name) / "source.yaml"
+            source.write_text(
+                yaml.safe_dump(
+                    {
+                        "Sensor Node": {
+                            "network_type": "IP",
+                            "hiprfisr_ip_address": "localhost",
+                        }
+                    }
+                )
+            )
+
+            with self.assertRaisesRegex(ConfigPreparationError, "reachable IPv4"):
+                prepare_remote_config(
+                    source,
+                    Path(temp_name) / "staged.yaml",
+                    FakeConnection("127.0.0.1"),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remote_sensor_node_deploy.py
+++ b/tests/test_remote_sensor_node_deploy.py
@@ -1,0 +1,374 @@
+"""Invariant tests for the AsyncSSH sensor-node deployment workflow."""
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+INSTALLER_DIR = Path(__file__).resolve().parents[1] / "Installer"
+sys.path.insert(0, str(INSTALLER_DIR))
+
+from deploy_remote_sensor_node import (  # noqa: E402
+    DeployOptions,
+    DeploymentError,
+    HostSpec,
+    build_service_unit,
+    connect,
+    copy_build_context,
+    heartbeat_is_ready,
+    parse_options,
+    prompt_for_ssh_password,
+    upload_payload,
+    validate_options,
+)
+
+
+def make_options(**overrides) -> DeployOptions:
+    values = {
+        "target": HostSpec("sensor.example", "fissure"),
+        "identity_file": None,
+        "config_file": Path("/missing/config.yaml"),
+        "certificates_dir": Path("/missing/certificates"),
+        "image_file": None,
+        "output_image": Path("/tmp/fissure-test.sif"),
+        "source_dir": Path("/missing/source"),
+        "remote_dir": "/opt/fissure-sensor-node",
+        "service_name": "fissure-sensor-node",
+        "health_timeout": 75,
+        "overlay_size_mb": 4096,
+        "startup_only": False,
+        "health_only": True,
+        "build_with_sudo": False,
+        "install_apptainer": True,
+        "uninstall": False,
+    }
+    values.update(overrides)
+    return DeployOptions(**values)
+
+
+class FakeAsyncSSH:
+    Error = RuntimeError
+
+    def __init__(self):
+        self.calls = []
+
+    async def connect(self, hostname, **kwargs):
+        self.calls.append((hostname, kwargs))
+        return object()
+
+
+class HostSpecTests(unittest.TestCase):
+    def test_parses_user_and_host(self):
+        self.assertEqual(
+            HostSpec.parse("fissure@sensor.example"),
+            HostSpec("sensor.example", "fissure"),
+        )
+        self.assertEqual(HostSpec.parse("[::1]"), HostSpec("::1", "root"))
+
+    def test_rejects_empty_or_option_like_host(self):
+        for target in ("", "user@", "--proxy"):
+            with self.subTest(target=target), self.assertRaises(DeploymentError):
+                HostSpec.parse(target)
+class DocoptCliTests(unittest.TestCase):
+    def test_defaults_are_mapped_to_deployment_options(self):
+        options = parse_options(["--target=fissure@sensor.example", "--health-only"])
+        self.assertEqual(options.target, HostSpec("sensor.example", "fissure"))
+        self.assertEqual(options.remote_dir, "/opt/fissure-sensor-node")
+        self.assertEqual(options.overlay_size_mb, 4096)
+        self.assertEqual(options.health_timeout, 75)
+        self.assertTrue(options.install_apptainer)
+        self.assertTrue(options.health_only)
+
+    def test_typed_values_and_service_suffix_are_normalized(self):
+        options = parse_options(
+            [
+                "--target=node.example",
+                "--overlay-size=1024",
+                "--service-name=fissure-node.service",
+                "--startup-only",
+                "--health-only",
+            ]
+        )
+        self.assertEqual(options.overlay_size_mb, 1024)
+        self.assertEqual(options.service_name, "fissure-node")
+        self.assertTrue(options.startup_only)
+
+    def test_short_identity_option_expands_the_key_path(self):
+        options = parse_options(
+            ["--target=root@sensor.example", "-i", "~/.ssh/fissure_node"]
+        )
+        self.assertEqual(
+            options.identity_file,
+            Path("~/.ssh/fissure_node").expanduser(),
+        )
+
+    def test_ip_only_defaults_to_root_and_installed_inputs(self):
+        options = parse_options(
+            [
+                "192.0.2.20",
+                "--source=/opt/FISSURE",
+                "--health-only",
+            ]
+        )
+
+        self.assertEqual(options.target, HostSpec("192.0.2.20", "root"))
+        self.assertEqual(
+            options.config_file,
+            Path("/opt/FISSURE/YAML/Sensor_Node_Config/default.yaml"),
+        )
+        self.assertEqual(
+            options.certificates_dir,
+            Path("/opt/FISSURE/certificates"),
+        )
+
+    def test_legacy_target_option_and_explicit_config_remain_supported(self):
+        options = parse_options(
+            [
+                "--target=192.0.2.20",
+                "--config=/tmp/sensor-node.yaml",
+                "--health-only",
+            ]
+        )
+
+        self.assertEqual(options.target, HostSpec("192.0.2.20", "root"))
+        self.assertEqual(options.config_file, Path("/tmp/sensor-node.yaml"))
+
+    def test_apptainer_auto_install_can_be_disabled(self):
+        options = parse_options(
+            [
+                "192.0.2.20",
+                "--no-install-apptainer",
+                "--health-only",
+            ]
+        )
+        self.assertFalse(options.install_apptainer)
+
+    def test_uninstall_is_parsed_without_local_inputs(self):
+        options = parse_options(
+            ["192.0.2.20", "--source=/missing/FISSURE", "--uninstall"]
+        )
+
+        self.assertTrue(options.uninstall)
+        validate_options(options)
+
+
+class ValidationTests(unittest.TestCase):
+    def test_rejects_broad_remote_roots(self):
+        for options in (
+            make_options(remote_dir="/"),
+            make_options(remote_dir="/opt"),
+            make_options(remote_dir="/opt/../etc"),
+        ):
+            with self.subTest(options=options), self.assertRaises(DeploymentError):
+                validate_options(options)
+
+    def test_existing_image_does_not_require_source_tree(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            config = root / "node.yaml"
+            image = root / "node.sif"
+            certificates = root / "certificates"
+            (certificates / "clients").mkdir(parents=True)
+            (certificates / "server").mkdir()
+            for path in (
+                config,
+                image,
+                certificates / "clients/client_0.key_secret",
+                certificates / "server/server.key",
+            ):
+                path.touch()
+            options = make_options(
+                config_file=config,
+                certificates_dir=certificates,
+                image_file=image,
+                health_only=False,
+            )
+            validate_options(options)
+
+    def test_certificate_inputs_are_mandatory(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            config, image = root / "node.yaml", root / "node.sif"
+            config.touch()
+            image.touch()
+            options = make_options(
+                config_file=config,
+                certificates_dir=root / "certificates",
+                image_file=image,
+                health_only=False,
+            )
+            with self.assertRaisesRegex(DeploymentError, "client_0.key_secret"):
+                validate_options(options)
+
+    def test_identity_must_be_a_file(self):
+        options = make_options(identity_file=Path("/missing/ssh-key"))
+        with self.assertRaisesRegex(DeploymentError, "SSH identity"):
+            validate_options(options)
+
+    def test_uninstall_and_health_only_are_mutually_exclusive(self):
+        options = make_options(uninstall=True, health_only=True)
+        with self.assertRaisesRegex(DeploymentError, "cannot be combined"):
+            validate_options(options)
+
+
+class ConnectionOptionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_identity_is_passed_to_asyncssh(self):
+        asyncssh = FakeAsyncSSH()
+        identity = Path("/keys/fissure-node")
+        await connect(
+            asyncssh,
+            make_options(
+                target=HostSpec("sensor.example", "root"),
+                identity_file=identity,
+            ),
+            password=None,
+        )
+
+        self.assertEqual(
+            asyncssh.calls,
+            [
+                (
+                    "sensor.example",
+                    {
+                        "keepalive_interval": 30,
+                        "username": "root",
+                        "client_keys": [str(identity)],
+                    },
+                )
+            ],
+        )
+
+    async def test_password_disables_implicit_key_authentication(self):
+        asyncssh = FakeAsyncSSH()
+        await connect(asyncssh, make_options(), password="test-password")
+
+        _, kwargs = asyncssh.calls[0]
+        self.assertIsNone(kwargs["client_keys"])
+        self.assertEqual(kwargs["password"], "test-password")
+
+    async def test_missing_authentication_is_rejected_before_connecting(self):
+        asyncssh = FakeAsyncSSH()
+        with self.assertRaisesRegex(DeploymentError, "password is required"):
+            await connect(asyncssh, make_options(), password=None)
+        self.assertEqual(asyncssh.calls, [])
+
+
+class PasswordPromptTests(unittest.TestCase):
+    @patch("deploy_remote_sensor_node.getpass.getpass")
+    def test_prompts_for_root_password_without_identity(self, get_password):
+        get_password.return_value = "test-password"
+
+        password = prompt_for_ssh_password(
+            make_options(target=HostSpec("sensor.example", "root"))
+        )
+
+        self.assertEqual(password, "test-password")
+        get_password.assert_called_once_with(
+            "SSH password for root@sensor.example: "
+        )
+
+    @patch("deploy_remote_sensor_node.getpass.getpass")
+    def test_identity_skips_password_prompt(self, get_password):
+        password = prompt_for_ssh_password(
+            make_options(identity_file=Path("/keys/fissure-node"))
+        )
+
+        self.assertIsNone(password)
+        get_password.assert_not_called()
+
+    @patch("deploy_remote_sensor_node.getpass.getpass", return_value="")
+    def test_empty_password_is_rejected(self, _get_password):
+        with self.assertRaisesRegex(DeploymentError, "cannot be empty"):
+            prompt_for_ssh_password(make_options())
+
+    @patch("deploy_remote_sensor_node.getpass.getpass", side_effect=EOFError)
+    def test_missing_secure_terminal_is_rejected(self, _get_password):
+        with self.assertRaisesRegex(DeploymentError, "securely"):
+            prompt_for_ssh_password(make_options())
+
+
+class DeploymentInvariantTests(unittest.TestCase):
+    def test_service_tracks_current_release_and_external_state(self):
+        options = make_options()
+        unit = build_service_unit(
+            options, "fissure", "fissure", "/usr/bin/apptainer"
+        )
+        self.assertIn("/opt/fissure-sensor-node/current/", unit)
+        self.assertIn("/opt/fissure-sensor-node/state/home", unit)
+        self.assertIn("/opt/fissure-sensor-node/state/runtime-overlay.img", unit)
+        self.assertIn("/certificates:/opt/FISSURE/certificates:ro", unit)
+
+    def test_ip_health_requires_a_current_hub_heartbeat(self):
+        options = make_options()
+        snapshot = {
+            "network_type": "IP",
+            "hiprfisr_connected": True,
+            "updated_at_epoch": 1_000,
+        }
+        self.assertTrue(heartbeat_is_ready(snapshot, 1_050, options))
+        self.assertFalse(heartbeat_is_ready(snapshot, 1_100, options))
+        self.assertFalse(
+            heartbeat_is_ready({**snapshot, "hiprfisr_connected": False}, 1_050, options)
+        )
+        self.assertTrue(
+            heartbeat_is_ready(snapshot, 2_000, make_options(startup_only=True))
+        )
+
+    def test_build_context_excludes_private_material(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            source, destination = root / "source", root / "copy"
+            (source / ".git").mkdir(parents=True)
+            (source / "certificates").mkdir()
+            (source / "nested").mkdir()
+            (source / "keep.txt").write_text("keep")
+            (source / ".git/config").write_text("secret")
+            (source / "certificates/private.key").write_text("secret")
+            (source / "nested/client.key_secret").write_text("secret")
+
+            copy_build_context(source, destination)
+
+            self.assertTrue((destination / "keep.txt").is_file())
+            self.assertFalse((destination / ".git").exists())
+            self.assertFalse((destination / "certificates").exists())
+            self.assertFalse((destination / "nested/client.key_secret").exists())
+
+
+class ScpTransferTests(unittest.IsolatedAsyncioTestCase):
+    async def test_payload_uses_scp_with_normalized_remote_names(self):
+        class FakeAsyncSSH:
+            def __init__(self):
+                self.calls = []
+
+            async def scp(self, source, destination):
+                self.calls.append((source, destination))
+
+        asyncssh = FakeAsyncSSH()
+        connection = object()
+        await upload_payload(
+            asyncssh,
+            connection,
+            "/tmp/fissure-node-deploy.test",
+            make_options(),
+            Path("/local/custom-name.sif"),
+            Path("/local/fissure-sensor-node.service"),
+        )
+
+        remote_names = [destination[1].rsplit("/", 1)[-1] for _, destination in asyncssh.calls]
+        self.assertEqual(
+            remote_names,
+            [
+                "fissure-sensor-node.sif",
+                "default.yaml",
+                "client_0.key_secret",
+                "server.key",
+                "fissure-sensor-node.service",
+            ],
+        )
+        self.assertTrue(all(destination[0] is connection for _, destination in asyncssh.calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remote_sensor_node_privilege.py
+++ b/tests/test_remote_sensor_node_privilege.py
@@ -1,0 +1,204 @@
+"""Privilege and prerequisite invariants for remote sensor-node deployment."""
+
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+
+INSTALLER_DIR = Path(__file__).resolve().parents[1] / "Installer"
+sys.path.insert(0, str(INSTALLER_DIR))
+
+from remote_sensor_node_privilege import (  # noqa: E402
+    PrivilegeContext,
+    PrivilegeError,
+    prepare_remote_environment,
+    run_root_command,
+    run_root_script,
+)
+
+
+class FakeRemoteResult:
+    def __init__(self, stdout="", stderr="", exit_status=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+class FakeRemoteConnection:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []
+
+    async def run(self, command, input=None, check=False):
+        self.calls.append(
+            {"command": command, "input": input, "check": check}
+        )
+        return self.results.pop(0)
+
+
+class RemoteBootstrapTests(unittest.IsolatedAsyncioTestCase):
+    async def test_uses_existing_apptainer_without_package_changes(self):
+        connection = FakeRemoteConnection(
+            [
+                FakeRemoteResult(
+                    "fissure|fissure|/usr/bin/apptainer|passwordless\n"
+                )
+            ]
+        )
+
+        environment = await prepare_remote_environment(
+            connection, "fissure@sensor", install_apptainer=True
+        )
+
+        self.assertEqual(environment.apptainer, "/usr/bin/apptainer")
+        self.assertEqual(environment.privilege.mode, "passwordless")
+        self.assertEqual(len(connection.calls), 1)
+
+    async def test_installs_missing_apptainer_as_root(self):
+        connection = FakeRemoteConnection(
+            [
+                FakeRemoteResult("fissure|fissure||passwordless\n"),
+                FakeRemoteResult(),
+                FakeRemoteResult("/usr/bin/apptainer\n"),
+            ]
+        )
+
+        environment = await prepare_remote_environment(
+            connection, "fissure@sensor", install_apptainer=True
+        )
+
+        self.assertEqual(environment.apptainer, "/usr/bin/apptainer")
+        install_call = connection.calls[1]
+        self.assertIn("sudo -n --", install_call["command"])
+        self.assertIn("ppa:apptainer/ppa", install_call["command"])
+        self.assertIn("amd64|arm64", install_call["command"])
+        self.assertIsNone(install_call["input"])
+
+    async def test_missing_apptainer_can_fail_without_installing(self):
+        connection = FakeRemoteConnection(
+            [FakeRemoteResult("fissure|fissure||passwordless\n")]
+        )
+
+        with self.assertRaisesRegex(PrivilegeError, "not installed"):
+            await prepare_remote_environment(
+                connection, "fissure@sensor", install_apptainer=False
+            )
+        self.assertEqual(len(connection.calls), 1)
+
+    async def test_install_failure_reports_remote_error(self):
+        connection = FakeRemoteConnection(
+            [
+                FakeRemoteResult("fissure|fissure||passwordless\n"),
+                FakeRemoteResult(
+                    stderr="Automatic installation is unsupported",
+                    exit_status=20,
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(PrivilegeError, "unsupported"):
+            await prepare_remote_environment(
+                connection, "fissure@sensor", install_apptainer=True
+            )
+        self.assertEqual(len(connection.calls), 2)
+
+
+class SudoPasswordTests(unittest.IsolatedAsyncioTestCase):
+    @patch(
+        "remote_sensor_node_privilege.getpass.getpass",
+        return_value="sudo-secret",
+    )
+    async def test_prompts_and_validates_sudo_password(self, get_password):
+        connection = FakeRemoteConnection(
+            [
+                FakeRemoteResult(
+                    "fissure|fissure|/usr/bin/apptainer|password\n"
+                ),
+                FakeRemoteResult(),
+            ]
+        )
+
+        environment = await prepare_remote_environment(
+            connection, "fissure@sensor", install_apptainer=True
+        )
+
+        get_password.assert_called_once_with(
+            "Sudo password for fissure@sensor: "
+        )
+        validation = connection.calls[1]
+        self.assertIn("sudo -k -S -p ''", validation["command"])
+        self.assertNotIn("sudo-secret", validation["command"])
+        self.assertEqual(validation["input"], "sudo-secret\n")
+        self.assertNotIn("sudo-secret", repr(environment.privilege))
+
+    @patch(
+        "remote_sensor_node_privilege.getpass.getpass",
+        return_value="wrong-password",
+    )
+    async def test_rejects_invalid_sudo_password(self, _get_password):
+        connection = FakeRemoteConnection(
+            [
+                FakeRemoteResult(
+                    "fissure|fissure|/usr/bin/apptainer|password\n"
+                ),
+                FakeRemoteResult(stderr="Sorry, try again.", exit_status=1),
+            ]
+        )
+
+        with self.assertRaisesRegex(PrivilegeError, "authentication failed"):
+            await prepare_remote_environment(
+                connection, "fissure@sensor", install_apptainer=True
+            )
+
+    @patch("remote_sensor_node_privilege.getpass.getpass", return_value="")
+    async def test_rejects_empty_sudo_password(self, _get_password):
+        connection = FakeRemoteConnection(
+            [
+                FakeRemoteResult(
+                    "fissure|fissure|/usr/bin/apptainer|password\n"
+                )
+            ]
+        )
+
+        with self.assertRaisesRegex(PrivilegeError, "cannot be empty"):
+            await prepare_remote_environment(
+                connection, "fissure@sensor", install_apptainer=True
+            )
+
+    async def test_password_is_stdin_only_for_privileged_scripts(self):
+        connection = FakeRemoteConnection([FakeRemoteResult()])
+        privilege = PrivilegeContext("password", "sudo-secret")
+
+        await run_root_script(
+            connection,
+            "echo installed",
+            ["/opt/fissure"],
+            privilege,
+        )
+
+        call = connection.calls[0]
+        self.assertNotIn("sudo-secret", call["command"])
+        self.assertIn("exec </dev/null", call["command"])
+        self.assertEqual(call["input"], "sudo-secret\n")
+
+
+class RootPrivilegeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_root_connection_does_not_invoke_sudo(self):
+        connection = FakeRemoteConnection([FakeRemoteResult()])
+
+        await run_root_command(
+            connection,
+            ["systemctl", "is-active", "fissure.service"],
+            PrivilegeContext("root"),
+        )
+
+        call = connection.calls[0]
+        self.assertIn("systemctl is-active fissure.service", call["command"])
+        self.assertIn("exec </dev/null", call["command"])
+        self.assertNotIn("sudo", call["command"])
+        self.assertIsNone(call["input"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remote_sensor_node_uninstall.py
+++ b/tests/test_remote_sensor_node_uninstall.py
@@ -1,0 +1,59 @@
+"""Uninstall invariants for remote Sensor Node deployments."""
+
+from pathlib import Path
+import sys
+import unittest
+
+
+INSTALLER_DIR = Path(__file__).resolve().parents[1] / "Installer"
+sys.path.insert(0, str(INSTALLER_DIR))
+
+from remote_sensor_node_uninstall import uninstall_remote  # noqa: E402
+
+
+class FakeResult:
+    def __init__(self, stdout="", stderr="", exit_status=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+class FakeConnection:
+    def __init__(self):
+        self.results = [FakeResult("passwordless\n"), FakeResult()]
+        self.calls = []
+
+    async def run(self, command, input=None, check=False):
+        self.calls.append(
+            {"command": command, "input": input, "check": check}
+        )
+        return self.results.pop(0)
+
+
+class RemoteUninstallTests(unittest.IsolatedAsyncioTestCase):
+    async def test_removes_only_service_and_deployment_root(self):
+        connection = FakeConnection()
+
+        await uninstall_remote(
+            connection,
+            "fissure@sensor.example",
+            "/opt/fissure-sensor-node",
+            "fissure-sensor-node",
+        )
+
+        self.assertEqual(len(connection.calls), 2)
+        preflight, uninstall = connection.calls
+        self.assertNotIn("apptainer", preflight["command"])
+        self.assertIn("sudo -n --", uninstall["command"])
+        self.assertIn(
+            'rm -rf --one-file-system -- "$root"',
+            uninstall["command"],
+        )
+        self.assertIn("/opt/fissure-sensor-node", uninstall["command"])
+        self.assertIn("fissure-sensor-node", uninstall["command"])
+        self.assertNotIn("apt-get", uninstall["command"])
+        self.assertIsNone(uninstall["input"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a one-command remote SensorNode deployer with SSH key or interactive password authentication and sudo prompting
- reuse or build an Ubuntu 24.04 Apptainer image locally, install Apptainer remotely when needed, and manage the node with systemd and rollback-aware health checks
- stage current FISSURE Sensor Node configuration and certificates as external runtime state, preserving identity and secrets across image upgrades
- add health-only, startup-only, and uninstall workflows plus deployment documentation

## Validation

- python3 -m unittest tests.test_remote_sensor_node_deploy tests.test_remote_sensor_node_privilege tests.test_remote_sensor_node_config tests.test_remote_sensor_node_uninstall
- python3 -m py_compile on all deployment modules and tests
- 38 unit tests pass
- manual image build and SensorNode startup were exercised; strict heartbeat validation correctly reported failure when HIPRFISR was not running

## Notes

- the generated 2.8 GB SIF is intentionally not committed
- uninstall removes the remote service and deployment state but preserves the remote Apptainer package and local cached SIF